### PR TITLE
Missing Rate Limiting vulnerability fix (powered by Mobb)

### DIFF
--- a/web_server/package.json
+++ b/web_server/package.json
@@ -30,6 +30,7 @@
     "ejs": "^3.1.7",
     "escape-string-regexp": "^1.0.5",
     "express": "^4.16.4",
+    "express-rate-limit": ">=7.4.0",
     "express-session": "^1.17.1",
     "jquery": "^3.3.1",
     "mongoose": "^6.2.5",

--- a/web_server/routes/core.js
+++ b/web_server/routes/core.js
@@ -12,6 +12,7 @@
  * governing permissions and limitations under the License.
  */
 
+const rateLimit = require('express-rate-limit');
 const express = require('express');
 const router = express.Router();
 
@@ -57,7 +58,7 @@ function getSessionParams(req) {
 }
 
 module.exports = function (envConfig) {
-    router.get('/', function (req, res) {
+    router.get('/', rateLimit({ limit: 60 }), function (req, res) {
         setHeaders(res);
         let params = getSessionParams(req);
         res.render('pages/index', params);


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Missing Rate Limiting** issue reported by **Snyk**.

## Issue description
The lack of a rate limit can allow denial-of-service attacks, in which an attacker can cause the application to crash or become unresponsive by issuing a large number of requests simultaneously.
 
## Fix instructions
Use express-rate-limit npm package to set a rate limit.

## Additional actions required
 We set the default limit to 60 requests per minute. To customize the rate limit settings, please read the documentation of the [express-rate-limit](https://www.npmjs.com/package/express-rate-limit) package.


[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/afc837fb-ecb7-4b3f-9eda-127127cca2c2/project/276cd1ed-64b7-496e-ad14-98eb6f55d5e0/report/5e1ed2cc-c70b-4f9a-9b77-707d3ba8c97b/fix/4d370c9b-e69e-44d8-af52-be79a355eb6a)